### PR TITLE
Add ESP32-P4 support

### DIFF
--- a/IRQ-Detection/main/Kconfig.projbuild
+++ b/IRQ-Detection/main/Kconfig.projbuild
@@ -7,7 +7,8 @@ menu "Application Configuration"
 		default 48 if IDF_TARGET_ESP32S3
 		default 18 if IDF_TARGET_ESP32C2
 		default 19 if IDF_TARGET_ESP32C3
-		default 30 if IDF_TARGET_ESP32C6
+                default 30 if IDF_TARGET_ESP32C6
+                default 54 if IDF_TARGET_ESP32P4
 
 	choice DIRECTION
 		prompt "Communication polarity"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ESP-IDF V5.1 is required when using ESP32-C6.
 ```Shell
 git clone https://github.com/nopnop2002/esp-idf-mirf
 cd esp-idf-mirf/Peer-to-peer
-idf.py set-target {esp32/esp32s2/esp32s3/esp32c2/esp32c3/esp32c6}
+idf.py set-target {esp32/esp32s2/esp32s3/esp32c2/esp32c3/esp32c6/esp32p4}
 idf.py menuconfig
 idf.py flash
 ```
@@ -71,7 +71,7 @@ nRF24L01 does not have Software Reset function.
 
 # Wirering
 
-|nRF24L01||ESP32|ESP32-S2/S3|ESP32-C2/C3/C6||
+|nRF24L01||ESP32|ESP32-S2/S3|ESP32-C2/C3/C6/P4||
 |:-:|:-:|:-:|:-:|:-:|:-:|
 |MISO|--|GPIO19|GPIO37|GPIO4|(*1)|
 |SCK|--|GPIO18|GPIO36|GPIO3|(*1)|

--- a/components/mirf/Kconfig.projbuild
+++ b/components/mirf/Kconfig.projbuild
@@ -7,7 +7,8 @@ menu "nRF24L01 Configuration"
 		default 48 if IDF_TARGET_ESP32S3
 		default 18 if IDF_TARGET_ESP32C2
 		default 19 if IDF_TARGET_ESP32C3
-		default 30 if IDF_TARGET_ESP32C6
+                default 30 if IDF_TARGET_ESP32C6
+                default 54 if IDF_TARGET_ESP32P4
 
 	config RADIO_CHANNEL
 		int "Channel number"


### PR DESCRIPTION
## Summary
- add ESP32-P4 configuration defaults
- document ESP32-P4 setup instructions

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7dca9a4083218242497a1a7a4764